### PR TITLE
Add academy link to menu

### DIFF
--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -25,6 +25,7 @@ const links: HeaderLink[] = [
   // { label: "Home", link: "/", showsAtHome: false },
   { label: "Manifesto", link: "#manifesto", showsAtHome: true },
   { label: "Speakers", link: "/speakers", showsAtHome: true },
+  { label: "Academy", link: "/academic-forum", showsAtHome: true },
   {
     label: "Apply as Speaker",
     link: "https://tally.so/r/w8EB0o",


### PR DESCRIPTION
Add "Academy" link to the main navigation menu, pointing to the academic forum page.