### PR TITLE
Update academy navigation menu display

### DIFF
--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -25,6 +25,7 @@ const links: HeaderLink[] = [
   // { label: "Home", link: "/", showsAtHome: false },
   { label: "Manifesto", link: "#manifesto", showsAtHome: true },
   { label: "Speakers", link: "/speakers", showsAtHome: true },
+  { label: "Academic Forum", link: "/academic-forum", showsAtHome: true },
   {
     label: "Apply as Speaker",
     link: "https://tally.so/r/w8EB0o",


### PR DESCRIPTION
Add 'Academic Forum' to the header navigation menu, linking to the existing academic forum page as requested.