### PR TITLE
Wrap speaker names to prevent overflow

### DIFF
--- a/app/now/now.tsx
+++ b/app/now/now.tsx
@@ -178,7 +178,7 @@ const Now: React.FC<NowProps> = ({ sessions, simulatedDate }) => {
                                       />
                                     )}
                                     <div className="flex flex-col max-w-48">
-                                      <Text>{speaker.name}</Text>
+                                      <Text className="break-words hyphens-auto">{speaker.name}</Text>
                                       <Text textType={"small"}>
                                         {speaker.description}
                                       </Text>
@@ -245,7 +245,7 @@ const Now: React.FC<NowProps> = ({ sessions, simulatedDate }) => {
                                     />
                                   )}
                                   <div className="flex flex-col max-w-48">
-                                    <Text>{speaker.name}</Text>
+                                    <Text className="break-words hyphens-auto">{speaker.name}</Text>
                                     <Text textType={"small"}>
                                       {speaker.description}
                                     </Text>

--- a/components/session/Session.tsx
+++ b/components/session/Session.tsx
@@ -227,7 +227,7 @@ export const Session = React.forwardRef<SessionElement, SessionProps>(
                       </Link>
                     )}
                     <div className="flex flex-col max-w-48">
-                      <Text key={index}>{speaker.name}</Text>
+                      <Text key={index} className="break-words hyphens-auto">{speaker.name}</Text>
                       <Text key={index} textType="small">
                         {speaker.description}
                       </Text>

--- a/components/speaker/Speaker.tsx
+++ b/components/speaker/Speaker.tsx
@@ -59,7 +59,7 @@ export const Speaker = React.forwardRef<HTMLDivElement, SpeakerProps>(
           height={275}
         />
         <div className={"flex flex-col gap-1 self-stretch"}>
-          <Text textType={"sub_title"} className={"font-bold"}>
+          <Text textType={"sub_title"} className={"font-bold break-words hyphens-auto"}>
             {name}
           </Text>
           <Text textType={"paragraph"}>


### PR DESCRIPTION
Add word and character wrapping to speaker names to prevent overflow and improve readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-7705514d-fa18-4d1d-aa92-4ed85fc70437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7705514d-fa18-4d1d-aa92-4ed85fc70437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>