### PR TITLE
Adjust sponsor box width on mobile

### DIFF
--- a/components/sponsor/Sponsor.tsx
+++ b/components/sponsor/Sponsor.tsx
@@ -11,11 +11,11 @@ const sponsorVariant = cva(
   {
     variants: {
       sponsorType: {
-        bronze: "w-[125px] h-[125px] md:w-[200px] md:h-[200px]",
-        silver: "w-[200px] h-[200px] md:w-[200px] md:h-[200px]",
-        gold: "w-[200px] h-[200px] md:w-[200px] md:h-[200px]",
+        bronze: "w-[100px] h-[100px] md:w-[200px] md:h-[200px]",
+        silver: "w-[140px] h-[140px] md:w-[200px] md:h-[200px]",
+        gold: "w-[140px] h-[140px] md:w-[200px] md:h-[200px]",
         platinum:
-          "w-[240px] h-[240px] md:w-[300px] md:h-[300px] border-gradient-tbc border-4",
+          "w-[180px] h-[180px] md:w-[300px] md:h-[300px] border-gradient-tbc border-4",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Reduce the width of sponsor boxes on mobile devices to improve responsiveness.

The existing `silver` and `gold` sponsor sizes were `200px` on all screen sizes, which was too wide for mobile. This change introduces mobile-specific sizing for all sponsor tiers, making them smaller on mobile while retaining their desktop sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-d303f306-147c-4326-9ff7-cde840a273f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d303f306-147c-4326-9ff7-cde840a273f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>