### PR TITLE
Adjust neodyme logo padding on mobile

### DIFF
--- a/sections/Sponsors.tsx
+++ b/sections/Sponsors.tsx
@@ -49,7 +49,7 @@ const bronzeSponsors: SponsorData[] = [
     alt: "neodyme",
     link: "https://neodyme.io/",
     imageSrc: "/sponsors/neodyme_logo.png",
-    className: "!p-9",
+    className: "!p-4 md:!p-9",
   },
   {
     alt: "Staking Facilities",


### PR DESCRIPTION
Decrease Neodyme logo padding on mobile to make it appear larger.

---
<a href="https://cursor.com/background-agent?bcId=bc-553fda96-8e6d-43f1-a6ab-46590b99e93d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-553fda96-8e6d-43f1-a6ab-46590b99e93d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>