### PR TITLE
Update side event times to Berlin timezone

### DIFF
--- a/components/event/Event.tsx
+++ b/components/event/Event.tsx
@@ -38,31 +38,60 @@ export const Event = React.forwardRef<EventElement, EventProps>(
       start.getFullYear() === end.getFullYear() &&
       start.getMonth() === end.getMonth() &&
       start.getDate() === end.getDate();
+
+    const berlinDateOptions: Intl.DateTimeFormatOptions = {
+      timeZone: "Europe/Berlin",
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    };
+
+    const berlinDateTimeOptions: Intl.DateTimeFormatOptions = {
+      timeZone: "Europe/Berlin",
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    };
+
+    const berlinTimeOptions: Intl.DateTimeFormatOptions = {
+      timeZone: "Europe/Berlin",
+      hour: "2-digit",
+      minute: "2-digit",
+    };
+
+    // Determine if the given date is in Berlin daylight saving time
+    const isBerlinDST = (date: Date): boolean => {
+      const year = date.getUTCFullYear();
+
+      // DST starts: last Sunday of March at 01:00 UTC
+      const lastDayOfMarch = new Date(Date.UTC(year, 3, 0));
+      const lastSundayOfMarchDate =
+        lastDayOfMarch.getUTCDate() - lastDayOfMarch.getUTCDay();
+      const dstStartUTC = new Date(
+        Date.UTC(year, 2, lastSundayOfMarchDate, 1, 0, 0),
+      );
+
+      // DST ends: last Sunday of October at 01:00 UTC
+      const lastDayOfOctober = new Date(Date.UTC(year, 10, 0));
+      const lastSundayOfOctoberDate =
+        lastDayOfOctober.getUTCDate() - lastDayOfOctober.getUTCDay();
+      const dstEndUTC = new Date(
+        Date.UTC(year, 9, lastSundayOfOctoberDate, 1, 0, 0),
+      );
+
+      return (
+        date.getTime() >= dstStartUTC.getTime() &&
+        date.getTime() < dstEndUTC.getTime()
+      );
+    };
+
+    const tzLabel = isBerlinDST(start) ? "CEST" : "CET";
+
     const dateDisplay = sameDay
-      ? `${start.toLocaleDateString(undefined, {
-          weekday: "long",
-          month: "long",
-          day: "numeric",
-        })} | ${start.toLocaleTimeString([], {
-          hour: "2-digit",
-          minute: "2-digit",
-        })} - ${end.toLocaleTimeString([], {
-          hour: "2-digit",
-          minute: "2-digit",
-        })}`
-      : `${start.toLocaleString(undefined, {
-          weekday: "long",
-          month: "long",
-          day: "numeric",
-          hour: "2-digit",
-          minute: "2-digit",
-        })} - ${end.toLocaleString(undefined, {
-          weekday: "long",
-          month: "long",
-          day: "numeric",
-          hour: "2-digit",
-          minute: "2-digit",
-        })}`;
+      ? `${start.toLocaleDateString(undefined, berlinDateOptions)} | ${start.toLocaleTimeString([], berlinTimeOptions)} - ${end.toLocaleTimeString([], berlinTimeOptions)} ${tzLabel}`
+      : `${start.toLocaleString(undefined, berlinDateTimeOptions)} - ${end.toLocaleString(undefined, berlinDateTimeOptions)} ${tzLabel}`;
 
     return (
       <div
@@ -70,10 +99,17 @@ export const Event = React.forwardRef<EventElement, EventProps>(
           className,
           "flex flex-col border border-white p-6 hover:scale-[102%] duration-500 ease-in-out overflow-hidden rounded-none",
         )}
+        ref={ref}
         {...restProps}
       >
         <div className="relative w-full aspect-square overflow-hidden rounded-none">
-          <Image className={"object-cover"} src={image} alt={title} title={title} fill />
+          <Image
+            className={"object-cover"}
+            src={image}
+            alt={title}
+            title={title}
+            fill
+          />
         </div>
         <Text textType={"sub_title"} as="p" className="mt-6 line-clamp-2">
           {title}
@@ -81,10 +117,19 @@ export const Event = React.forwardRef<EventElement, EventProps>(
         <Text className="mt-2 underline truncate" textType={"small"} as="p">
           {dateDisplay}
         </Text>
-        <Text className="mt-2 text-gray-400 line-clamp-3" textType={"small"} as="p">
+        <Text
+          className="mt-2 text-gray-400 line-clamp-3"
+          textType={"small"}
+          as="p"
+        >
           {description}
         </Text>
-        <NextLink className="mt-auto" href={link} target="_blank" rel="noopener noreferrer">
+        <NextLink
+          className="mt-auto"
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Button className="mt-4" buttonType={"cta"}>
             Learn More
           </Button>

--- a/components/event/Event.tsx
+++ b/components/event/Event.tsx
@@ -34,10 +34,15 @@ export const Event = React.forwardRef<EventElement, EventProps>(
 
     const start = new Date(startTime);
     const end = new Date(endTime);
-    const sameDay =
-      start.getFullYear() === end.getFullYear() &&
-      start.getMonth() === end.getMonth() &&
-      start.getDate() === end.getDate();
+    const berlinDateKey = (date: Date): string =>
+      new Intl.DateTimeFormat("en-CA", {
+        timeZone: "Europe/Berlin",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(date);
+
+    const sameDay = berlinDateKey(start) === berlinDateKey(end);
 
     const berlinDateOptions: Intl.DateTimeFormatOptions = {
       timeZone: "Europe/Berlin",


### PR DESCRIPTION
Display event times in Berlin timezone, dynamically showing CET or CEST based on the date.

---
<a href="https://cursor.com/background-agent?bcId=bc-010b88ba-1ace-445d-9772-aad87944a54d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-010b88ba-1ace-445d-9772-aad87944a54d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

