### PR TITLE
Add Giessecke Devrient and CryptoNews partners

### DIFF
--- a/sections/Partners.tsx
+++ b/sections/Partners.tsx
@@ -72,6 +72,7 @@ const Partners = () => {
     { alt: "CryptoNewsZ", src: "/partners/cryptonewsz_logo.png" },
     { alt: "DroomDroom", src: "/partners/DroomDroom_logo.png" },
     { alt: "TheNewsCrypto", src: "/partners/thenewscrypto_logo.png" },
+    { alt: "CryptoNews", src: "/partners/cryptonews_logo.png" },
     // { alt: "Web3 Vision", src: "/partners/w3.vision_white.png" },
     // { alt: "Werk1", src: "/partners/werk1.png" },
     // { alt: "BTC Echo", src: "/partners/btc_echo_logo.png" },

--- a/sections/Sponsors.tsx
+++ b/sections/Sponsors.tsx
@@ -96,6 +96,11 @@ const bronzeSponsors: SponsorData[] = [
     link: "https://zircuit.com/",
     imageSrc: "/sponsors/zircuit_logo.png",
   },
+  {
+    alt: "Giessecke Devrient",
+    link: "https://www.gi-de.com/",
+    imageSrc: "/sponsors/giesecke_devrient_logo.png",
+  },
 ];
 
 // Helper function to chunk an array into groups of specified size


### PR DESCRIPTION
Add Giessecke Devrient as a bronze sponsor and CryptoNews as a media partner.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bf2baf7-032d-4d85-8368-01cdf06c4aa7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bf2baf7-032d-4d85-8368-01cdf06c4aa7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

